### PR TITLE
Release v1.2.0 and start v1.2.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.2.0 2021-06-04
+* Update version of `org.folio:edge-common` from `2.0.2` to `3.0.0`
+
 ## 1.1.0 2021-06-04
 * Added ability to use Box.com API for direct-download of reserves.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-lti-courses</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.2.0</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Course Reserves LTI Tool</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-lti-courses.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-lti-courses.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-lti-courses.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.2.0</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-lti-courses</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Course Reserves LTI Tool</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-lti-courses.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-lti-courses.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-lti-courses.git</developerConnection>
-    <tag>v1.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>2.0.2</version>
+      <version>3.0.0</version>
     </dependency>
 
      <dependency>


### PR DESCRIPTION
This release bumps the version of `edge-common` used from 2.0.2 to 3.0.0