### PR TITLE
Added rendering when discoverySuppress is on

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.3.0 IN PROGRESS
+* Added different reserve-item rendering for reserve-instances that have `discoverySuppress` enabled.
+
 ## 1.2.0 2021-06-04
 * Update version of `org.folio:edge-common` from `2.0.2` to `3.0.0`
 

--- a/src/main/java/org/folio/edge/ltiCourses/model/Reserve.java
+++ b/src/main/java/org/folio/edge/ltiCourses/model/Reserve.java
@@ -16,6 +16,8 @@ public class Reserve {
   public String primaryContributor;
   public String startDate;
   public String endDate;
+  public String locationDisplayName;
+  public Boolean suppressDiscovery;
 
   public Reserve(JsonObject json) {
     this.itemId = json.getString("itemId", "");
@@ -30,6 +32,11 @@ public class Reserve {
     this.instanceHrid = item.getString("instanceHrid", "");
     this.title = item.getString("title", "");
     this.uri = item.getString("uri", "");
+    this.suppressDiscovery = item.getBoolean("instanceDiscoverySuppress", false);
+
+    // Get the physical location, preferring the temporary location over the permanent location.
+    this.locationDisplayName = item.getJsonObject("permanentLocationObject", new JsonObject()).getString("discoveryDisplayName", "?");
+    this.locationDisplayName = item.getJsonObject("temporaryLocationObject", new JsonObject()).getString("discoveryDisplayName", this.locationDisplayName);
 
     Iterator<Object> i = item
       .getJsonArray("contributors", new JsonArray())
@@ -63,6 +70,8 @@ public class Reserve {
       .put("uri", uri)
       .put("startDate", startDate)
       .put("endDate", endDate)
-      .put("primaryContributor", primaryContributor);
+      .put("primaryContributor", primaryContributor)
+      .put("locationDisplayName", locationDisplayName)
+      .put("suppressDiscovery", suppressDiscovery);
   }
 }

--- a/src/main/java/org/folio/edge/ltiCourses/utils/LtiCoursesOkapiClient.java
+++ b/src/main/java/org/folio/edge/ltiCourses/utils/LtiCoursesOkapiClient.java
@@ -32,7 +32,6 @@ public class LtiCoursesOkapiClient extends OkapiClient {
     }
 
     get(
-      // okapiURL + "/configurations/entries?limit=100&query=(module=EDGELTICOURSES+and+configName=" + issuerQuery + ")",
       okapiURL + "/configurations/entries?limit=100&query=(module=EDGELTICOURSES+and+configName=platform+and+code=" + issuerQuery + ")",
       tenant,
       responseHandler,

--- a/src/main/resources/templates/ResourceLinkResponse.jade
+++ b/src/main/resources/templates/ResourceLinkResponse.jade
@@ -1,8 +1,15 @@
 mixin reserve-list-item(reserve)
   li(class="reserve-list-item")
-    a(class="reserve-url" href=reserve.getString("uri") target="_parent") #{reserve.getString("title")}
+    if reserve.getBoolean("suppressDiscovery")
+      span(class="reserve-title") #{reserve.getString("title")}
+    else
+      a(class="reserve-url" href=reserve.getString("uri") target="_parent") #{reserve.getString("title")}
+
     if (reserve.getString("primaryContributor"))
       span  - #{reserve.getString("primaryContributor")}
+
+    if (reserve.getBoolean("suppressDiscovery"))
+      span &nbsp;(available at #{reserve.getString("locationDisplayName")})
 
 ul(class="lti-course-reserves-list")
   each reserve in reserves

--- a/src/test/java/org/folio/edge/ltiCourses/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/ltiCourses/MainVerticleTest.java
@@ -299,6 +299,36 @@ public class MainVerticleTest {
   }
 
   @Test
+  public void testResourceLinkRequestForCourseWithReservesThatHaveSuppressedDiscovery(TestContext context) {
+    logger.info("=== Test Resource Link requests for course with reserves that have suppressed discovery... ===");
+
+    final Response oidcResponse = performOIDCLoginInit();
+    HashMap<String, String> oidcResponseParams = getOIDCLoginQueryParams(oidcResponse.header("location"));
+
+    String nonce = oidcResponseParams.get("nonce");
+    String state = oidcResponseParams.get("state");
+
+    String id_token = getResourceLinkJWT(mockOkapi.courseWithReserves, nonce);
+
+    Response response = RestAssured
+      .given()
+        .formParam("id_token", id_token)
+        .formParam("state", state)
+      .when()
+        .post("/lti-courses/launches/" + apiKey)
+      .then()
+        .statusCode(200)
+        .contentType("text/html;charset=UTF-8")
+        .extract()
+        .response();
+
+    String body = response.getBody().asString();
+    assertEquals(true, body.contains("(available at Secret Shelf)"));
+    assertEquals(true, body.contains("(available at Public Shelf)"));
+    assertEquals(false, body.contains("(available at Never Visible)"));
+  }
+
+  @Test
   public void testResourceLinkRequestForCourseWithoutReserves(TestContext context) {
     logger.info("=== Test Resource Link requests for course without reserves... ===");
 

--- a/src/test/java/org/folio/edge/ltiCourses/utils/LtiCoursesMockOkapi.java
+++ b/src/test/java/org/folio/edge/ltiCourses/utils/LtiCoursesMockOkapi.java
@@ -87,6 +87,28 @@ public class LtiCoursesMockOkapi extends MockOkapi {
       reserves.add(new JsonObject()
         .put("itemId", "bar")
         .put("barcode", "456")
+        .put("copiedItem", new JsonObject()
+          .put("permanentLocationObject", new JsonObject().put("discoveryDisplayName", "Never Visible")) // This should never be visible because discovery isn't suppressed
+        )
+      );
+
+      reserves.add(new JsonObject()
+        .put("itemId", "permanentSecretLocation")
+        .put("barcode", "invalid1")
+        .put("copiedItem", new JsonObject()
+          .put("permanentLocationObject", new JsonObject().put("discoveryDisplayName", "Secret Shelf"))
+          .put("instanceDiscoverySuppress", true)
+        )
+      );
+
+      reserves.add(new JsonObject()
+        .put("itemId", "temporaryKnownLocation")
+        .put("barcode", "invalid2")
+        .put("copiedItem", new JsonObject()
+          .put("permanentLocationObject", new JsonObject().put("discoveryDisplayName", "Secret Shelf"))
+          .put("temporaryLocationObject", new JsonObject().put("discoveryDisplayName", "Public Shelf"))
+          .put("instanceDiscoverySuppress", true)
+        )
       );
     }
 


### PR DESCRIPTION
Some reserve items are linked to an instance that has been suppressed from discovery. In these cases, it doesn't make sense to render a link to the discovery layer, so we render text with the effective location of the item instead.

This will use functionality added in https://github.com/folio-org/mod-courses/pull/131, but has graceful degradation with versions of mod-courses that do not have that functionality.