### PR TITLE
Fixed bug so items with electronic access always render their URI

### DIFF
--- a/src/main/java/org/folio/edge/ltiCourses/model/Reserve.java
+++ b/src/main/java/org/folio/edge/ltiCourses/model/Reserve.java
@@ -18,6 +18,7 @@ public class Reserve {
   public String endDate;
   public String locationDisplayName;
   public Boolean suppressDiscovery;
+  public Boolean hasElectronicAccess;
 
   public Reserve(JsonObject json) {
     this.itemId = json.getString("itemId", "");
@@ -33,6 +34,7 @@ public class Reserve {
     this.title = item.getString("title", "");
     this.uri = item.getString("uri", "");
     this.suppressDiscovery = item.getBoolean("instanceDiscoverySuppress", false);
+    this.hasElectronicAccess = this.uri.length() > 0;
 
     // Get the physical location, preferring the temporary location over the permanent location.
     this.locationDisplayName = item.getJsonObject("permanentLocationObject", new JsonObject()).getString("discoveryDisplayName", "?");
@@ -72,6 +74,7 @@ public class Reserve {
       .put("endDate", endDate)
       .put("primaryContributor", primaryContributor)
       .put("locationDisplayName", locationDisplayName)
-      .put("suppressDiscovery", suppressDiscovery);
+      .put("suppressDiscovery", suppressDiscovery)
+      .put("hasElectronicAccess", hasElectronicAccess);
   }
 }

--- a/src/main/resources/templates/ResourceLinkResponse.jade
+++ b/src/main/resources/templates/ResourceLinkResponse.jade
@@ -1,6 +1,6 @@
 mixin reserve-list-item(reserve)
   li(class="reserve-list-item")
-    if reserve.getBoolean("suppressDiscovery")
+    if (reserve.getBoolean("suppressDiscovery") && !reserve.getBoolean("hasElectronicAccess"))
       span(class="reserve-title") #{reserve.getString("title")}
     else
       a(class="reserve-url" href=reserve.getString("uri") target="_parent") #{reserve.getString("title")}
@@ -8,7 +8,7 @@ mixin reserve-list-item(reserve)
     if (reserve.getString("primaryContributor"))
       span  - #{reserve.getString("primaryContributor")}
 
-    if (reserve.getBoolean("suppressDiscovery"))
+    if (reserve.getBoolean("suppressDiscovery") && !reserve.getBoolean("hasElectronicAccess"))
       span &nbsp;(available at #{reserve.getString("locationDisplayName")})
 
 ul(class="lti-course-reserves-list")

--- a/src/test/java/org/folio/edge/ltiCourses/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/ltiCourses/MainVerticleTest.java
@@ -323,9 +323,23 @@ public class MainVerticleTest {
         .response();
 
     String body = response.getBody().asString();
-    assertEquals(true, body.contains("(available at Secret Shelf)"));
-    assertEquals(true, body.contains("(available at Public Shelf)"));
+
+    // searchURL should be rendered with barcode interpolated
+    assertEquals(true, body.contains("barcode_123"));
+
+    // searchURL should be rendered with barcode despite existence of location object
     assertEquals(false, body.contains("(available at Never Visible)"));
+    assertEquals(true, body.contains("barcode_456"));
+
+    // suppressed from discovery with permanent location
+    assertEquals(true, body.contains("(available at Secret Shelf)"));
+
+    // suppressed from discovery with temporary location
+    assertEquals(true, body.contains("(available at Public Shelf)"));
+
+    // electronic access URI should be rendered despite suppressed discovery
+    assertEquals(false, body.contains("(available at Not Visible)"));
+    assertEquals(true, body.contains("http://foobar.com"));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/ltiCourses/MockLtiPlatform.java
+++ b/src/test/java/org/folio/edge/ltiCourses/MockLtiPlatform.java
@@ -41,7 +41,7 @@ public class MockLtiPlatform {
     this.noReservesMessage = "No reserves :(";
     this.oauthTokenUrl = "http://localhost:" + port + "/token";
     this.oidcAuthUrl = "http://localhost:" + port + "/oidc";
-    this.searchUrl = "http://localhost:" + port + "/search";
+    this.searchUrl = "http://localhost:" + port + "/search?barcode=[BARCODE]";
   }
 
   public JsonObject asJsonObject() {

--- a/src/test/java/org/folio/edge/ltiCourses/utils/LtiCoursesMockOkapi.java
+++ b/src/test/java/org/folio/edge/ltiCourses/utils/LtiCoursesMockOkapi.java
@@ -81,21 +81,23 @@ public class LtiCoursesMockOkapi extends MockOkapi {
     if (courseWithReserves.equals(ctx.request().getParam("courseId"))) {
       reserves.add(new JsonObject()
         .put("itemId", "foo")
-        .put("barcode", "123")
+        .put("copiedItem", new JsonObject()
+          .put("barcode", "barcode_123")
+        )
       );
 
       reserves.add(new JsonObject()
         .put("itemId", "bar")
-        .put("barcode", "456")
         .put("copiedItem", new JsonObject()
+          .put("barcode", "barcode_456")
           .put("permanentLocationObject", new JsonObject().put("discoveryDisplayName", "Never Visible")) // This should never be visible because discovery isn't suppressed
         )
       );
 
       reserves.add(new JsonObject()
         .put("itemId", "permanentSecretLocation")
-        .put("barcode", "invalid1")
         .put("copiedItem", new JsonObject()
+          .put("barcode", "invalid1")
           .put("permanentLocationObject", new JsonObject().put("discoveryDisplayName", "Secret Shelf"))
           .put("instanceDiscoverySuppress", true)
         )
@@ -103,13 +105,24 @@ public class LtiCoursesMockOkapi extends MockOkapi {
 
       reserves.add(new JsonObject()
         .put("itemId", "temporaryKnownLocation")
-        .put("barcode", "invalid2")
         .put("copiedItem", new JsonObject()
+          .put("barcode", "invalid2")
           .put("permanentLocationObject", new JsonObject().put("discoveryDisplayName", "Secret Shelf"))
           .put("temporaryLocationObject", new JsonObject().put("discoveryDisplayName", "Public Shelf"))
           .put("instanceDiscoverySuppress", true)
         )
       );
+
+      reserves.add(new JsonObject()
+      .put("itemId", "permanentSecretLocation")
+      .put("copiedItem", new JsonObject()
+        .put("barcode", "invalid3")
+        .put("permanentLocationObject", new JsonObject().put("discoveryDisplayName", "Not Visible")) // This should never be visible because the item has a `uri`
+        .put("instanceDiscoverySuppress", true)
+        .put("uri", "http://foobar.com")
+      )
+    );
+
     }
 
     ctx.response()


### PR DESCRIPTION
Items that are suppressed from discovery and have electronic access URIs defined **should in fact** be rendered as links, they should not be rendered as spans with the personal item text of ` (Available at ${effectiveLocation})`

Fixed that and added a test for it.