### PR TITLE
EDGLTI-7: Upgrade to edge-common 4.5.2 to make compatible with RTR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM folioci/alpine-jre-openjdk11:latest
+FROM folioci/alpine-jre-openjdk17:latest
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
 
 ENV VERTICLE_FILE edge-lti-courses-fat.jar
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,13 @@
 buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 
   doDocker = {
     buildJavaDocker {
       publishMaster = 'yes'
       healthChk = 'yes'
-      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/admin/health || exit 1'
+      healthChkCmd = 'wget --no-verbose --tries=1 --spider http://localhost:8081/admin/health || exit 1'
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.4.1</version>
+        <version>4.4.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.4.3</version>
+      <version>4.5.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/EDGLTI-7

This wraps `OkapiClient` so by upgrading that to the latest edge-common it gets RTR.