### PR TITLE
EDGLTI-13: box-java-sdk 4.9.1 fixing vulns in jose4j, okio-jvm, bc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,16 +90,7 @@
     <dependency>
         <groupId>com.box</groupId>
         <artifactId>box-java-sdk</artifactId>
-        <version>4.1.0</version>
-    </dependency>
-
-    <!-- remove when box-java-sdk ships with jose4j >= 0.9.3
-         https://security.snyk.io/vuln/SNYK-JAVA-ORGBITBUCKETBC-5488281
-    -->
-    <dependency>
-    <groupId>org.bitbucket.b_c</groupId>
-    <artifactId>jose4j</artifactId>
-    <version>0.9.3</version>
+        <version>4.9.1</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGLTI-13

Upgrade box-java-sdk from 4.1.0 to 4.9.1.

The box-java-sdk upgrade indirectly upgrades jose4j from 0.9.3 to 0.9.4 fixing Denial of Service (DoS):

https://www.cve.org/CVERecord?id=CVE-2023-51775

The box-java-sdk upgrade indirectly upgrades okio-jvm from 3.0.0 to 3.6.0 fixing GZIP Denial of Service (DoS):

https://nvd.nist.gov/vuln/detail/CVE-2023-3635

The box-java-sdk upgrade indirectly upgrades from bcprov-jdk15on:1.70 to bcprov-jdk18on:1.78.1 fixing OOM:

https://nvd.nist.gov/vuln/detail/CVE-2023-33202
https://www.cve.org/CVERecord?id=CVE-2024-29857