### PR TITLE
EDGLTI-16: Vert.x 4.5.8 fixing netty-codec-http OOM CVE-2024-29025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.5.3</version>
+        <version>4.5.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGLTI-16

Upgrade Vertx from 4.5.3 to 4.5.8.

The Vertx upgrade indirectly upgrades netty-codec-http from 4.1.106.Final to 4.1.110.Final fixing form POST OOM:

https://github.com/netty/netty/security/advisories/GHSA-5jpm-x58v-624v = CVE-2024-29025