### PR TITLE
bump up edge-common to v4.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.7.0</version>
+      <version>4.7.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
bump up edge-common to v4.7.1: AwsParamStore to support FIPS-approved crypto modules